### PR TITLE
Don't use dpkg architecture for dkms

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -10,12 +10,11 @@ PACKAGE_NAME=thinkpad-wmi-dkms
 
 VERSION=`dpkg-query -W -f='${Version}' $PACKAGE_NAME | awk -F "-" '{print $1}' \
 	| cut -d\: -f2`
-ARCH=`dpkg --print-architecture`
 
 dkms_configure () {
 	for POSTINST in /usr/lib/dkms/common.postinst "/usr/share/$PACKAGE_NAME/postinst"; do
 		if [ -f "$POSTINST" ]; then
-			"$POSTINST" "$PACKAGE_NAME" "$VERSION" "/usr/share/$PACKAGE_NAME" "$ARCH" "$2"
+			"$POSTINST" "$PACKAGE_NAME" "$VERSION" "/usr/share/$PACKAGE_NAME" "" "$2"
 			return $?
 		fi
 		echo "WARNING: $POSTINST does not exist." >&2


### PR DESCRIPTION
For example on intel 64 bit machines the dpkg architecture is amd64, but uname -m is x86_64, so building this module from dpkg postinst results in a different architecture than building it manually.

From man 8 dkms: "-a, --arch The system architecture to perform the action upon.  It is optional if you pass it as part of the -k option. If not specified, it assumes the arch of the currently running system (`uname -m`)."

Looking at /usr/lib/dkms/common.postinst and the postinst of other dkms modules, e.g. v4l2loopback, we can just pass an empty string as the positional arch argument, forcing dkms to use `uname -m` to figure out the correct arch consistently.