### PR TITLE
Fixed compilation error for kernel version 5.5.9

### DIFF
--- a/drivers/platform/x86/thinkpad-wmi.c
+++ b/drivers/platform/x86/thinkpad-wmi.c
@@ -1134,11 +1134,9 @@ static int thinkpad_wmi_debugfs_init(struct thinkpad_wmi *thinkpad)
 	if (!dent)
 		goto error_debugfs;
 
-	dent = debugfs_create_u8("instance", S_IRUGO | S_IWUSR,
+	debugfs_create_u8("instance", S_IRUGO | S_IWUSR,
 				 thinkpad->debug.root,
 				 &thinkpad->debug.instance);
-	if (!dent)
-		goto error_debugfs;
 
 	dent = debugfs_create_u32("instances_count", S_IRUGO,
 				 thinkpad->debug.root,


### PR DESCRIPTION
Recently the AUR package `thinkpad_wmi-dkms-git` has been broken for me. I tracked it down to this error message during compilation:

```
DKMS make.log for thinkpad-wmi-r37.2a85aa1 for kernel 5.5.9-arch1-2 (x86_64)
Mon 16 Mar 2020 15:30:42 AEDT
make -C /lib/modules/5.5.9-arch1-2/build M=/var/lib/dkms/thinkpad-wmi/r37.2a85aa1/build thinkpad-wmi.ko
make[1]: Entering directory '/usr/lib/modules/5.5.9-arch1-2/build'
  AR      /var/lib/dkms/thinkpad-wmi/r37.2a85aa1/build/built-in.a
  CC [M]  /var/lib/dkms/thinkpad-wmi/r37.2a85aa1/build/thinkpad-wmi.o
/var/lib/dkms/thinkpad-wmi/r37.2a85aa1/build/thinkpad-wmi.c: In function ‘thinkpad_wmi_debugfs_init’:
/var/lib/dkms/thinkpad-wmi/r37.2a85aa1/build/thinkpad-wmi.c:1137:7: error: void value not ignored as it ought to be
 1137 |  dent = debugfs_create_u8("instance", S_IRUGO | S_IWUSR,
      |       ^
make[2]: *** [scripts/Makefile.build:266: /var/lib/dkms/thinkpad-wmi/r37.2a85aa1/build/thinkpad-wmi.o] Error 1
make[1]: *** [Makefile:1693: /var/lib/dkms/thinkpad-wmi/r37.2a85aa1/build] Error 2
make[1]: Leaving directory '/usr/lib/modules/5.5.9-arch1-2/build'
make: *** [Makefile:12: default] Error 2
```

With my fix I've been able to compile the driver now on kernel version 5.5.9 and have tested it out. I'm unsure whether this change breaks the driver on older kernel versions.