### PR TITLE
Removed return value assignment for debugfs_create_u32

### DIFF
--- a/drivers/platform/x86/thinkpad-wmi.c
+++ b/drivers/platform/x86/thinkpad-wmi.c
@@ -1138,7 +1138,7 @@ static int thinkpad_wmi_debugfs_init(struct thinkpad_wmi *thinkpad)
 				 thinkpad->debug.root,
 				 &thinkpad->debug.instance);
 
-	dent = debugfs_create_u32("instances_count", S_IRUGO,
+	debugfs_create_u32("instances_count", S_IRUGO,
 				 thinkpad->debug.root,
 				 &thinkpad->debug.instances_count);
 	if (!dent)


### PR DESCRIPTION
Similar to the last pull request I made: https://github.com/iksaif/thinkpad-wmi/pull/16

Trying to install on a newer kernel version (specifically 5.7.7-arch1-1), caused compilation errors with the assignment 

```c
dent = debugfs_create_u32("instances_count", S_IRUGO,
				 thinkpad->debug.root,
				 thinkpad->debug.root,
				 &thinkpad->debug.instances_count);
```

Removing `dent = ` seems to fix this compilation error.

The patch is listed here: https://linuxlists.cc/l/1/linux-kernel/t/3537734/(patch)_debugfs:_remove_return_value_of_debugfs_create_u32()#post3537734 - but isn't reflected in the kernel docs (https://www.kernel.org/doc/Documentation/filesystems/debugfs.txt).

This may break older kernel versions, I don't have older devices to test on sorry.